### PR TITLE
player-item collisions, killzones, camera collider

### DIFF
--- a/Assets/Animations/Fireball_Explode.anim
+++ b/Assets/Animations/Fireball_Explode.anim
@@ -20,13 +20,13 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: -7300928910054741501, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: 7181844927105529402, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     - time: 0.125
-      value: {fileID: 5905092277533087384, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: 4757675256894538741, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     - time: 0.25
-      value: {fileID: 7181844927105529402, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: 7838358312946088296, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     attribute: m_Sprite
     path: 
@@ -47,9 +47,9 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: -7300928910054741501, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
-    - {fileID: 5905092277533087384, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
     - {fileID: 7181844927105529402, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
+    - {fileID: 4757675256894538741, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
+    - {fileID: 7838358312946088296, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Fireball_Spin.anim
+++ b/Assets/Animations/Fireball_Spin.anim
@@ -20,16 +20,16 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: -2683122828085155042, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: 1672004093104025019, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     - time: 0.125
-      value: {fileID: -6368990107354976361, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: -1314892338991186924, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     - time: 0.25
-      value: {fileID: 4459968514413365290, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: -6559532512907405437, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     - time: 0.375
-      value: {fileID: 8649575011220892221, guid: b789decba8ffcc34fb784f87bd318a82,
+      value: {fileID: 5905092277533087384, guid: b789decba8ffcc34fb784f87bd318a82,
         type: 3}
     attribute: m_Sprite
     path: 
@@ -50,10 +50,10 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: -2683122828085155042, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
-    - {fileID: -6368990107354976361, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
-    - {fileID: 4459968514413365290, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
-    - {fileID: 8649575011220892221, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
+    - {fileID: 1672004093104025019, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
+    - {fileID: -1314892338991186924, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
+    - {fileID: -6559532512907405437, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
+    - {fileID: 5905092277533087384, guid: b789decba8ffcc34fb784f87bd318a82, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Player/PlayerAnimationController.controller
+++ b/Assets/Animations/Player/PlayerAnimationController.controller
@@ -158,6 +158,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-7228517425224910984
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: playerState
+    m_EventTreshold: 2
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4559863443035620390}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-7156180332950942624
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -617,12 +642,13 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Player_small_run
-  m_Speed: 0.3
+  m_Speed: 0.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8578707119818425199}
   - {fileID: -583072790327611419}
   - {fileID: 9169464415762666647}
+  - {fileID: 7285169078867221001}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -652,6 +678,7 @@ AnimatorState:
   - {fileID: 2090022218143445252}
   - {fileID: -4866667027889668318}
   - {fileID: -1649012279324350014}
+  - {fileID: -7228517425224910984}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -780,6 +807,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: 784021958268098612}
   - {fileID: -3052550296285906449}
+  - {fileID: 2000080299255033330}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -834,31 +862,31 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: grounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 1
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: playerState
     m_Type: 3
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: playerDie
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: shootFireball
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -1049,6 +1077,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &2000080299255033330
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: playerState
+    m_EventTreshold: 2
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4559863443035620390}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2090022218143445252
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1225,37 +1278,37 @@ AnimatorStateMachine:
     m_Position: {x: -350, y: 250, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4401927651885307954}
-    m_Position: {x: 330, y: -310, z: 0}
+    m_Position: {x: 190, y: -280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8196272348573336710}
-    m_Position: {x: 590, y: -360, z: 0}
+    m_Position: {x: 450, y: -330, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1567981809953977075}
-    m_Position: {x: 590, y: -250, z: 0}
+    m_Position: {x: 450, y: -220, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 868941709288769512}
-    m_Position: {x: 400, y: -100, z: 0}
+    m_Position: {x: 310, y: -70, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6977341301104422884}
-    m_Position: {x: 190, y: -100, z: 0}
+    m_Position: {x: 100, y: -70, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6544276326803074421}
-    m_Position: {x: 240, y: -700, z: 0}
+    m_Position: {x: 580, y: -720, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4559863443035620390}
-    m_Position: {x: 380, y: -490, z: 0}
+    m_Position: {x: 720, y: -510, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4905996998057481701}
-    m_Position: {x: 490, y: -720, z: 0}
+    m_Position: {x: 830, y: -740, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 9133757488396012440}
-    m_Position: {x: 610, y: -610, z: 0}
+    m_Position: {x: 950, y: -630, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 2423818872920833077}
-    m_Position: {x: 150, y: -490, z: 0}
+    m_Position: {x: 490, y: -510, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 900400108635074791}
-    m_Position: {x: 590, y: -900, z: 0}
+    m_Position: {x: 930, y: -920, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: -3864726311722214009}
@@ -1300,7 +1353,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Player_fire_run
-  m_Speed: 1
+  m_Speed: 0.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -5035684871038517352}
@@ -1312,13 +1365,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: e74efdc960ab76346ae667fd44d2389a, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -1449,6 +1502,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &7285169078867221001
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: playerState
+    m_EventTreshold: 2
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4559863443035620390}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &7586669394220375007
 AnimatorState:
   serializedVersion: 5
@@ -1509,7 +1587,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Player_big_run
-  m_Speed: 1
+  m_Speed: 0.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 3022777585142582946}

--- a/Assets/Prefabs/Blocks/BrickBlock.prefab
+++ b/Assets/Prefabs/Blocks/BrickBlock.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5226911960986676408}
   - component: {fileID: 12277356553883639}
+  - component: {fileID: -9151229700241961316}
   m_Layer: 0
   m_Name: BrickBlock
   m_TagString: Untagged
@@ -67,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 7021444480197847261, guid: 1704c0199ad85c5458f634156e409b59,
     type: 3}
@@ -82,3 +83,29 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &-9151229700241961316
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3360684124594602560}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.16, y: 0.16}
+    newSize: {x: 0.16, y: 0.16}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.16, y: 0.16}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Blocks/GroundBlock.prefab
+++ b/Assets/Prefabs/Blocks/GroundBlock.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: a73a45ab8959da145a3ad9ce213fc0ed, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Blocks/ItemBlock.prefab
+++ b/Assets/Prefabs/Blocks/ItemBlock.prefab
@@ -71,8 +71,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 5396632630363886753, guid: 1704c0199ad85c5458f634156e409b59,
     type: 3}
@@ -134,7 +134,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 7781634852708793238}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -160,7 +160,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 7781634852708793238}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Blocks/StepBlock.prefab
+++ b/Assets/Prefabs/Blocks/StepBlock.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 3573036208370857778, guid: 0cda94c91f97c6044a84fae002647d15,
     type: 3}
@@ -92,7 +92,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 9112545774180962310}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Blocks/UGbrickBlock.prefab
+++ b/Assets/Prefabs/Blocks/UGbrickBlock.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: -1699742857459110359, guid: 1704c0199ad85c5458f634156e409b59,
     type: 3}
@@ -92,7 +92,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 4330337404857121589}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Blocks/UGgroundBlock.prefab
+++ b/Assets/Prefabs/Blocks/UGgroundBlock.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 645588284522800376, guid: 6f87eb1476bdd8643b3ec3228982b8ce, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -91,7 +91,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 5346385948890598364}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Items/FireFlower.prefab
+++ b/Assets/Prefabs/Items/FireFlower.prefab
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8419331675724922625
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8419331675724922626}
+  - component: {fileID: 8419331675724922627}
+  - component: {fileID: 8419331675724922624}
+  m_Layer: 0
+  m_Name: FireFlower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8419331675724922626
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8419331675724922625}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.74, y: -0.87, z: -13.947086}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &8419331675724922627
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8419331675724922625}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &8419331675724922624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8419331675724922625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6ddf71bf5813c0429c3f876acfe7a1e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Items/FireFlower.prefab.meta
+++ b/Assets/Prefabs/Items/FireFlower.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 024d7983a9fa5f44cbe2f272938f213d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Items/RedMushroom.prefab
+++ b/Assets/Prefabs/Items/RedMushroom.prefab
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1427595260673160981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1427595260673160982}
+  - component: {fileID: 1427595260673160983}
+  - component: {fileID: 1427595260673160980}
+  m_Layer: 0
+  m_Name: RedMushroom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1427595260673160982
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427595260673160981}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.55, y: -3.17, z: -14.519043}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1427595260673160983
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427595260673160981}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &1427595260673160980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427595260673160981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b13e80cefe4a364886a1e97f18564b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Items/RedMushroom.prefab.meta
+++ b/Assets/Prefabs/Items/RedMushroom.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 516787220cd29674c8db46e0ee608a4c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Level/Castle.prefab
+++ b/Assets/Prefabs/Level/Castle.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: -3699113918209397617, guid: f77e340fda7f1ba41929543a18ccda01,
     type: 3}

--- a/Assets/Prefabs/Level/Flag.prefab
+++ b/Assets/Prefabs/Level/Flag.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: -1511796362308611940, guid: f77e340fda7f1ba41929543a18ccda01,
     type: 3}

--- a/Assets/Prefabs/Level/PipeA.prefab
+++ b/Assets/Prefabs/Level/PipeA.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 3681900039096042098, guid: f77e340fda7f1ba41929543a18ccda01,
     type: 3}
@@ -92,7 +92,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 5532229754925633499}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Level/PipeB.prefab
+++ b/Assets/Prefabs/Level/PipeB.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: -8685099284046981242, guid: f77e340fda7f1ba41929543a18ccda01,
     type: 3}
@@ -92,7 +92,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 8980510363486529851}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Level/PipeC.prefab
+++ b/Assets/Prefabs/Level/PipeC.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 1513431043496232673, guid: f77e340fda7f1ba41929543a18ccda01,
     type: 3}
@@ -92,7 +92,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 3120723281411223402}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Level/PipeD.prefab
+++ b/Assets/Prefabs/Level/PipeD.prefab
@@ -68,8 +68,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1902030273
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 7096035374257309606, guid: f77e340fda7f1ba41929543a18ccda01,
     type: 3}
@@ -92,7 +92,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 4419053359056085907}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: a4a05902e858a0c48bb752e37c058ad8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Mario/Player.prefab
+++ b/Assets/Prefabs/Mario/Player.prefab
@@ -102,6 +102,36 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!1 &2359525693836681834
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2340403960529047453}
+  m_Layer: 0
+  m_Name: FireballShootPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2340403960529047453
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2359525693836681834}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.079, y: 0.177, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2677584607891178421}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5106717300150948914
 GameObject:
   m_ObjectHideFlags: 0
@@ -143,6 +173,7 @@ GameObject:
   - component: {fileID: 2677584607891178421}
   - component: {fileID: 8759575946316033870}
   - component: {fileID: 2696133530889890086}
+  - component: {fileID: 5346792814723837687}
   - component: {fileID: 144538324838108523}
   m_Layer: 0
   m_Name: Player
@@ -164,6 +195,7 @@ Transform:
   m_Children:
   - {fileID: 5106717300150948915}
   - {fileID: 163585817}
+  - {fileID: 2340403960529047453}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -201,17 +233,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   groundCheckRadius: 0.05
-  hFrrictionMultiplier: 1
-  lowJumpMultiplier: 2
-  fallMultiplier: 2
-  jumpHeight: 5
-  maxSpeed: 20
-  accelTime: 0.5
+  hFrrictionMultiplier: 10
+  lowJumpMultiplier: 3
+  fallMultiplier: 4
+  jumpHeight: 12
+  maxSpeed: 5
+  accelTime: 0.1
   groundLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1
   groundCheckT: {fileID: 5106717300150948915}
   canMove: 0
+--- !u!114 &5346792814723837687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8759575946316033864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1eb27d2d28172a248ba6a2d6ab6ced25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fireballPrefab: {fileID: 1351294162629917604, guid: 4cd6c25f2f3d6234fba67f919b8b2e4b,
+    type: 3}
+  shootPosition: {fileID: 2340403960529047453}
 --- !u!70 &144538324838108523
 CapsuleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Mario/Player.prefab
+++ b/Assets/Prefabs/Mario/Player.prefab
@@ -102,6 +102,53 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!1 &385423817559187739
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5878421055901929152}
+  - component: {fileID: 5964779773558545187}
+  m_Layer: 0
+  m_Name: BigCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5878421055901929152
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 385423817559187739}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2677584607891178421}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &5964779773558545187
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 385423817559187739}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.00093504786, y: 0.1622126}
+  m_Size: {x: 0.16633171, y: 0.3244252}
+  m_Direction: 0
 --- !u!1 &2359525693836681834
 GameObject:
   m_ObjectHideFlags: 0
@@ -174,6 +221,7 @@ GameObject:
   - component: {fileID: 8759575946316033870}
   - component: {fileID: 2696133530889890086}
   - component: {fileID: 5346792814723837687}
+  - component: {fileID: 5627428390957199338}
   - component: {fileID: 144538324838108523}
   m_Layer: 0
   m_Name: Player
@@ -196,6 +244,8 @@ Transform:
   - {fileID: 5106717300150948915}
   - {fileID: 163585817}
   - {fileID: 2340403960529047453}
+  - {fileID: 26137285188930809}
+  - {fileID: 5878421055901929152}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -259,6 +309,18 @@ MonoBehaviour:
   fireballPrefab: {fileID: 1351294162629917604, guid: 4cd6c25f2f3d6234fba67f919b8b2e4b,
     type: 3}
   shootPosition: {fileID: 2340403960529047453}
+--- !u!114 &5627428390957199338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8759575946316033864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb21fd09f7aec8e4eafb7648eec88eed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!70 &144538324838108523
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -266,7 +328,7 @@ CapsuleCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8759575946316033864}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
@@ -274,4 +336,51 @@ CapsuleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0.08483829}
   m_Size: {x: 0.16, y: 0.17579155}
+  m_Direction: 0
+--- !u!1 &8781769229596823172
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 26137285188930809}
+  - component: {fileID: 8891033511779041876}
+  m_Layer: 0
+  m_Name: SmallCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &26137285188930809
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8781769229596823172}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2677584607891178421}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &8891033511779041876
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8781769229596823172}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.0021473765, y: 0.08341167}
+  m_Size: {x: 0.137236, y: 0.16682334}
   m_Direction: 0

--- a/Assets/Prefabs/Mario/Player.prefab
+++ b/Assets/Prefabs/Mario/Player.prefab
@@ -142,7 +142,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2677584607891178421}
   - component: {fileID: 8759575946316033870}
-  - component: {fileID: 8759575946316033865}
+  - component: {fileID: 2696133530889890086}
   - component: {fileID: 144538324838108523}
   m_Layer: 0
   m_Name: Player
@@ -188,7 +188,7 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 4
---- !u!114 &8759575946316033865
+--- !u!114 &2696133530889890086
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -197,19 +197,19 @@ MonoBehaviour:
   m_GameObject: {fileID: 8759575946316033864}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 96e74f88c3a8bde4da312a7701ccd8bc, type: 3}
+  m_Script: {fileID: 11500000, guid: 000e3c74feeb8a74bbee6e7cd93d651d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   groundCheckRadius: 0.05
-  hFrrictionMultiplier: 10
-  lowJumpMultiplier: 3
-  fallMultiplier: 4
-  jumpHeight: 12
-  maxSpeed: 5
-  accelTime: 0.1
+  hFrrictionMultiplier: 1
+  lowJumpMultiplier: 2
+  fallMultiplier: 2
+  jumpHeight: 5
+  maxSpeed: 20
+  accelTime: 0.5
   groundLayer:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 0
   groundCheckT: {fileID: 5106717300150948915}
   canMove: 0
 --- !u!70 &144538324838108523

--- a/Assets/Scenes/Level.unity
+++ b/Assets/Scenes/Level.unity
@@ -796,6 +796,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 42742554}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &43049076 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+    type: 3}
+  m_PrefabInstance: {fileID: 109237944}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &43897606
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2673,6 +2679,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 106325282}
   m_CullTransparentMesh: 0
+--- !u!1001 &109237944
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.8956919
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.2600899
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2696133530889890086, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: groundLayer.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8759575946316033864, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9f9584defc106ee4193f8da5cc3b1394, type: 3}
 --- !u!1001 &109828422
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16940,7 +17020,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &612973674
 PrefabInstance:
@@ -17350,8 +17430,8 @@ MonoBehaviour:
   cameraStartT: {fileID: 1539179684}
   undergroundCamT: {fileID: 378899148}
   returnPipeT: {fileID: 977783008}
-  playerT: {fileID: 1837449895}
-  moveOffset: 3
+  playerT: {fileID: 43049076}
+  moveOffset: 2
   canCameraMove: 1
 --- !u!4 &636651817
 Transform:
@@ -49007,12 +49087,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1835204067}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1837449895 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-    type: 3}
-  m_PrefabInstance: {fileID: 1921304527}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1840387123
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -51263,113 +51337,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1917911844}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1921304527
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1825791639, guid: 6e117297e82f2f9419c5069496c29b68, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1825791639, guid: 6e117297e82f2f9419c5069496c29b68, type: 3}
-      propertyPath: m_ApplyRootMotion
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2677584607891178421, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8759575946316033864, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_Name
-      value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 8759575946316033865, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: jumpHeight
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 8759575946316033865, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: hFrrictionMultiplier
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 8759575946316033870, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_Constraints
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 8759575946316033870, guid: 6e117297e82f2f9419c5069496c29b68,
-        type: 3}
-      propertyPath: m_GravityScale
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6e117297e82f2f9419c5069496c29b68, type: 3}
 --- !u!1001 &1921866829
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -53791,7 +53758,7 @@ RectTransform:
   - {fileID: 1378481446}
   - {fileID: 1496669303}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -54941,7 +54908,7 @@ Transform:
   - {fileID: 8467993764619774592}
   - {fileID: 5079320254650478252}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2048756547
 PrefabInstance:
@@ -57633,7 +57600,7 @@ PrefabInstance:
     - target: {fileID: 692025522381350477, guid: e44b94095e0cf494ab297ae8928f5511,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 692025522381350477, guid: e44b94095e0cf494ab297ae8928f5511,
         type: 3}
@@ -57732,7 +57699,7 @@ PrefabInstance:
     - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
         type: 3}

--- a/Assets/Scenes/Level.unity
+++ b/Assets/Scenes/Level.unity
@@ -2686,6 +2686,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 163585816, guid: 9f9584defc106ee4193f8da5cc3b1394, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2359525693836681834, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 2677584607891178421, guid: 9f9584defc106ee4193f8da5cc3b1394,
         type: 3}
       propertyPath: m_RootOrder
@@ -2751,9 +2760,24 @@ PrefabInstance:
       propertyPath: groundLayer.m_Bits
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5106717300150948914, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 8759575946316033864, guid: 9f9584defc106ee4193f8da5cc3b1394,
         type: 3}
       propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 8759575946316033864, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8759575946316033864, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
+      propertyPath: m_TagString
       value: Player
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -12869,40 +12893,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 463202482}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &465816585 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1843322965785545336, guid: ecad67e1b3993354fadbba51383d9c6a,
-    type: 3}
-  m_PrefabInstance: {fileID: 2339356412870568571}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &465816586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 465816585}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1a5be89ba627e23468f5d2a19305dc7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!58 &465816587
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 465816585}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.12}
-  serializedVersion: 2
-  m_Radius: 0.12
 --- !u!1001 &465936453
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14939,7 +14929,8 @@ GameObject:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
-  m_Layer: 0
+  - component: {fileID: 519420030}
+  m_Layer: 9
   m_Name: Main Camera
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
@@ -14954,6 +14945,32 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_Enabled: 1
+--- !u!61 &519420030
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -8.12509, y: 0.055576324}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.333435, y: 9.336277}
+  m_EdgeRadius: 0
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
@@ -17025,7 +17042,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &612973674
 PrefabInstance:
@@ -17453,7 +17470,7 @@ Transform:
   - {fileID: 378899148}
   - {fileID: 977783008}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &637993203
 PrefabInstance:
@@ -21344,6 +21361,63 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 781820604}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &782293766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 782293768}
+  - component: {fileID: 782293767}
+  m_Layer: 0
+  m_Name: KillZones
+  m_TagString: KillZone
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &782293767
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 782293766}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 25.743916, y: -0.031633377}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 55.547028, y: 0.93673325}
+  m_EdgeRadius: 0
+--- !u!4 &782293768
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 782293766}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 34.41, y: -5.44, z: -8.765625}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &789471849
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34638,7 +34712,7 @@ Transform:
   - {fileID: 1353699539}
   - {fileID: 929404193}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1324529508
 PrefabInstance:
@@ -40489,7 +40563,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1539179683}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.24, y: 1.63, z: 0}
+  m_LocalPosition: {x: 2.79, y: 1.63, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 636651817}
@@ -53763,7 +53837,7 @@ RectTransform:
   - {fileID: 1378481446}
   - {fileID: 1496669303}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -54913,7 +54987,7 @@ Transform:
   - {fileID: 8467993764619774592}
   - {fileID: 5079320254650478252}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2048756547
 PrefabInstance:
@@ -57605,7 +57679,7 @@ PrefabInstance:
     - target: {fileID: 692025522381350477, guid: e44b94095e0cf494ab297ae8928f5511,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 692025522381350477, guid: e44b94095e0cf494ab297ae8928f5511,
         type: 3}
@@ -57679,85 +57753,75 @@ PrefabInstance:
       objectReference: {fileID: 1496669304}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e44b94095e0cf494ab297ae8928f5511, type: 3}
---- !u!1001 &2339356412870568571
+--- !u!1001 &1427595260331012429
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1843322965785545336, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160981, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_Name
-      value: MarioSml
+      value: RedMushroom
       objectReference: {fileID: 0}
-    - target: {fileID: 3237542246121464874, guid: ecad67e1b3993354fadbba51383d9c6a,
-        type: 3}
-      propertyPath: m_SortingOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3237542246121464874, guid: ecad67e1b3993354fadbba51383d9c6a,
-        type: 3}
-      propertyPath: m_SpriteSortPoint
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 11
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.35
+      value: 1.55
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.81
+      value: -3.17
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -14.519043
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4984427686855632517, guid: ecad67e1b3993354fadbba51383d9c6a,
+    - target: {fileID: 1427595260673160982, guid: 516787220cd29674c8db46e0ee608a4c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ecad67e1b3993354fadbba51383d9c6a, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 516787220cd29674c8db46e0ee608a4c, type: 3}
 --- !u!1001 &3120723281314737403
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -57842,7 +57906,7 @@ PrefabInstance:
     - target: {fileID: 4130800253864236866, guid: 4a0d938bee525254d8be9ef2c0b7ad98,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4130800253864236866, guid: 4a0d938bee525254d8be9ef2c0b7ad98,
         type: 3}
@@ -58051,6 +58115,75 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7469641426980678304}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8419331676612826897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8419331675724922625, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_Name
+      value: FireFlower
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.947086
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8419331675724922626, guid: 024d7983a9fa5f44cbe2f272938f213d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 024d7983a9fa5f44cbe2f272938f213d, type: 3}
 --- !u!1001 &8467993764619774591
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level.unity
+++ b/Assets/Scenes/Level.unity
@@ -2743,6 +2743,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2696133530889890086, guid: 9f9584defc106ee4193f8da5cc3b1394,
         type: 3}
+      propertyPath: fallMultiplier
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2696133530889890086, guid: 9f9584defc106ee4193f8da5cc3b1394,
+        type: 3}
       propertyPath: groundLayer.m_Bits
       value: 1
       objectReference: {fileID: 0}
@@ -14972,7 +14977,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
+  near clip plane: -1
   far clip plane: 1000
   field of view: 60
   orthographic: 1

--- a/Assets/Scripts/CameraScript.cs
+++ b/Assets/Scripts/CameraScript.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraScript : MonoBehaviour
+{
+    [SerializeField] Transform cameraT, cameraStartT, undergroundCamT, returnPipeT, playerT;
+    [SerializeField] float moveOffset;
+    public bool canCameraMove = true;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        cameraT.position = cameraStartT.position;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (canCameraMove)
+        {
+            //camera will move right when player gets close to edge of screen, distance determined by moveOffset
+            if (playerT.position.x > cameraT.position.x + moveOffset)
+            {
+                cameraT.position = new Vector3(playerT.position.x - moveOffset, cameraT.position.y, cameraT.position.z);
+            }
+        }
+    }
+
+    //move camera to underground level, turn off camera movement
+    //use transform of empty object at position you want camera to teleport to
+    public void MoveCamUnderground()
+    {
+        cameraT.position = undergroundCamT.position;
+        canCameraMove = false;
+    }
+
+    //move camera to return pipe, turn on camera movement
+    //use transform of empty object at position you want camera to teleport to
+    public void MoveCameraReturnPipe()
+    {
+        cameraT.position = returnPipeT.position;
+        canCameraMove = true;
+
+    }
+}

--- a/Assets/Scripts/CameraScript.cs.meta
+++ b/Assets/Scripts/CameraScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b715877ea994564eb13c8b4452f4e0e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items/FireFlowerController.cs
+++ b/Assets/Scripts/Items/FireFlowerController.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FireFlowerController : MonoBehaviour
+{
+
+    private PlayerController pController;
+    // Start is called before the first frame update
+    void Start()
+    {
+        pController = GameObject.FindGameObjectWithTag("Player").GetComponent<PlayerController>();
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.tag == "Player")
+        {
+            pController.IncreaseMarioState();
+            pController.IncreaseMarioState();
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Items/FireFlowerController.cs.meta
+++ b/Assets/Scripts/Items/FireFlowerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6ddf71bf5813c0429c3f876acfe7a1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items/RedMushroomController.cs
+++ b/Assets/Scripts/Items/RedMushroomController.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RedMushroomController : MonoBehaviour
+{
+
+    private PlayerController pController;
+    // Start is called before the first frame update
+    void Start()
+    {
+        pController = GameObject.FindGameObjectWithTag("Player").GetComponent<PlayerController>();
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.tag == "Player")
+        {
+            pController.IncreaseMarioState();
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Items/RedMushroomController.cs.meta
+++ b/Assets/Scripts/Items/RedMushroomController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b13e80cefe4a364886a1e97f18564b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerCollisions.cs
+++ b/Assets/Scripts/Player/PlayerCollisions.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerCollisions : MonoBehaviour
+{
+    private Animator pAnimator;
+    private LivesManager livesManager;
+    // Start is called before the first frame update
+    void Start()
+    {
+        pAnimator = GetComponentInChildren<Animator>();
+        GameObject constantManagers = GameObject.FindGameObjectWithTag("ConstantManagers");
+        livesManager = constantManagers.GetComponentInChildren<LivesManager>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.tag == "KillZone")
+        {
+            pAnimator.SetTrigger("playerDie");
+            livesManager.LoseLife();
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerCollisions.cs.meta
+++ b/Assets/Scripts/Player/PlayerCollisions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb21fd09f7aec8e4eafb7648eec88eed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -19,8 +19,9 @@ public class PlayerController : MonoBehaviour
     private int maxNumOfFireballs = 2;
     private int currentNumOfFireballs = 0;
 
-    
-    
+
+    private LivesManager livesManager;
+
 
     // Start is called before the first frame update
     void Start()
@@ -28,6 +29,10 @@ public class PlayerController : MonoBehaviour
         playerMovement = GetComponent<PlayerMovement>();
         anim = GetComponentInChildren<Animator>();
         playerCol = GetComponent<CapsuleCollider2D>();
+
+
+        GameObject constantManagers = GameObject.FindGameObjectWithTag("ConstantManagers");
+        livesManager = constantManagers.GetComponentInChildren<LivesManager>();
     }
 
     // Update is called once per frame
@@ -78,6 +83,8 @@ public class PlayerController : MonoBehaviour
         {
             //Lives Manager . Lose Life
             Debug.Log("LOSE");
+            anim.SetTrigger("playerDie");
+            livesManager.LoseLife();
         }
     }
 

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -11,6 +11,7 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField] private Transform groundCheckT;
     private Vector2 refVel = Vector2.zero;
     private Animator pAnimator;
+    private float scaleMagnitude;
 
     
     public bool canMove;
@@ -24,6 +25,7 @@ public class PlayerMovement : MonoBehaviour
     void Start()
     {
         playerT = gameObject.transform;
+        scaleMagnitude = playerT.localScale.x;
         canMove = true;
         rb2d = GetComponent<Rigidbody2D>();
         pAnimator = GetComponentInChildren<Animator>();
@@ -44,10 +46,6 @@ public class PlayerMovement : MonoBehaviour
         pAnimator.SetFloat("speed", Mathf.Abs(xSpeed));
 
         //flip sprite around based on movement speed
-        if (faceRight && xSpeed < 0)
-            Flip();
-        if (!faceRight && xSpeed > 0)
-            Flip();
 
         if (canMove)
         {
@@ -109,6 +107,24 @@ public class PlayerMovement : MonoBehaviour
         Vector2 targetVelocity = new Vector2(Input.GetAxisRaw("Horizontal") * maxSpeed, rb2d.velocity.y);
         rb2d.velocity = Vector2.SmoothDamp(rb2d.velocity, targetVelocity, ref refVel, accelTime);
         //Debug.Log("Moving " + Input.GetAxisRaw("Horizontal"));
+
+        if (faceRight && targetVelocity.x < 0)
+        {
+            faceRight = false;
+            Vector3 scale = playerT.localScale;
+            scale.x = scaleMagnitude * -1;
+            playerT.localScale = scale;
+
+        }
+
+        if (!faceRight && targetVelocity.x > 0)
+        {
+            faceRight = true;
+            Vector3 scale = playerT.localScale;
+            scale.x = scaleMagnitude;
+            playerT.localScale = scale;
+
+        }
     }
 
     //makes player jump

--- a/Assets/Sprites/blocks.png.meta
+++ b/Assets/Sprites/blocks.png.meta
@@ -91,7 +91,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -124,7 +124,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -136,7 +136,19 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/Sprites/items-objects.png.meta
+++ b/Assets/Sprites/items-objects.png.meta
@@ -4,13 +4,13 @@ TextureImporter:
   internalIDToNameTable:
   - first:
       213: -6559532512907405437
-    second: items-objects_4
+    second: fb3
   - first:
       213: 5905092277533087384
-    second: items-objects_5
+    second: fb4
   - first:
       213: 7181844927105529402
-    second: items-objects_6
+    second: fbex1
   - first:
       213: 2983617987829867648
     second: items-objects_10
@@ -110,6 +110,18 @@ TextureImporter:
   - first:
       213: -7541339219011965739
     second: items-objects_1
+  - first:
+      213: 1672004093104025019
+    second: fb1
+  - first:
+      213: -1314892338991186924
+    second: fb2
+  - first:
+      213: 4757675256894538741
+    second: fbex2
+  - first:
+      213: 7838358312946088296
+    second: fbex3
   externalObjects: {}
   serializedVersion: 11
   mipmaps:
@@ -568,6 +580,153 @@ TextureImporter:
       bones: []
       spriteID: 5dce110afe7c75790800000000000000
       internalID: -7541339219011965739
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fb1
+      rect:
+        serializedVersion: 2
+        x: 96
+        y: 72
+        width: 8
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: bbde6703dd6243710800000000000000
+      internalID: 1672004093104025019
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fb2
+      rect:
+        serializedVersion: 2
+        x: 104
+        y: 72
+        width: 8
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 41c3c80626090cde0800000000000000
+      internalID: -1314892338991186924
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fb3
+      rect:
+        serializedVersion: 2
+        x: 96
+        y: 64
+        width: 8
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 3875783feebd7f4a0800000000000000
+      internalID: -6559532512907405437
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fb4
+      rect:
+        serializedVersion: 2
+        x: 104
+        y: 64
+        width: 8
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 8961340d32a13f150800000000000000
+      internalID: 5905092277533087384
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fbex1
+      rect:
+        serializedVersion: 2
+        x: 112
+        y: 64
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a36f01009e90ba360800000000000000
+      internalID: 7181844927105529402
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fbex2
+      rect:
+        serializedVersion: 2
+        x: 112
+        y: 48
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5f34ddb5078a60240800000000000000
+      internalID: 4757675256894538741
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: fbex3
+      rect:
+        serializedVersion: 2
+        x: 112
+        y: 32
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 869b1613b5177cc60800000000000000
+      internalID: 7838358312946088296
       vertices: []
       indices: 
       edges: []

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: fffdfffffffdfffffffdfffffffffffffffdfffffffdffffffffffffffffffffffffffffc8ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -9,6 +9,7 @@ TagManager:
   - Enemy
   - LeftTopEnemy
   - RightTopEnemy
+  - KillZone
   layers:
   - Default
   - TransparentFX
@@ -18,8 +19,8 @@ TagManager:
   - UI
   - 
   - 
-  - 
-  - 
+  - Player
+  - ScreenEdge
   - 
   - 
   - 


### PR DESCRIPTION
created red mushroom and fire flower prefabs (only collider/script) and have working collisions/implementation with player. (used same method used on lifemushroom and coin items)

added killzones in pitfall traps.

re-added collider on camera so you can't walk backwards (won't collide with enemies)

dying from player controller script or killzones will trigger loselife method in lives manager

added bigger collider on player prefab (needs to be toggled in playercontroller script)

player-enemy collision not implemented yet